### PR TITLE
Optimize Ethereum block loading with single-pass transaction cache

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -53,6 +53,19 @@ This document outlines the high-impact, focused improvements made to the Ethereu
 - **Implementation**: Defensive copying in getter methods
 - **Benefits**: Prevents external modification of internal data structures
 
+### 8. ✅ Massive Throughput Upgrade - Single-Pass Transaction Cache
+- **Impact**: Eliminated repeated full-file scans when constructing block objects
+- **Implementation**: Added a static transaction cache that loads `ethereumtransactions1.csv` once and indexes by block number + transaction index
+- **Benefits**: Data load time drops dramatically because transaction parsing is now O(total transactions) once, not O(blocks × total transactions)
+
+### 9. ✅ Reliability Fixes in Core Analytics
+- **Impact**: Prevented edge-case failures and made analytics more intuitive
+- **Implementation**:
+  - `avgTransactionCost()` now returns `0.0` for blocks with no transactions (no divide-by-zero)
+  - `transactionDiff()` now works regardless of argument order
+  - `sortBlocksByNumber()` now uses the correct default dataset path
+- **Benefits**: Better production behavior with less surprising runtime output
+
 ## Performance Metrics
 
 ### Before Improvements:

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -188,7 +188,11 @@ public class EthereumBlockExplorer {
     
     private static void viewUniqueMiners() {
         System.out.println("\n===== UNIQUE MINERS =====");
-        Blocks.calUniqMiners();
+        try {
+            Blocks.calUniqMiners();
+        } catch (Exception e) {
+            System.err.println("\nError: " + e.getMessage());
+        }
     }
     
     private static void compareBlocks() {


### PR DESCRIPTION
### Motivation
- Remove the massive startup cost from re-reading the entire transactions CSV for every `Blocks` construction by parsing transactions once and reusing the results. 
- Fix a few correctness and edge-case behaviors (divide-by-zero for empty blocks, incorrect default path, order-sensitivity in transaction diffs). 
- Harden the CLI so a failed miner-count operation won't crash the explorer.

### Description
- Added a single-pass transaction cache: `transactionsByBlock` and `ensureTransactionCacheLoaded(String)` to parse `ethereumtransactions1.csv` once and index transactions by block number and transaction index for deterministic ordering. `readTransactions()` now hydrates block transaction lists from that cache rather than rescanning the file. (see `src/Blocks.java`)
- Made `avgTransactionCost()` return `0.0` when a block has no transactions to avoid divide-by-zero errors. (see `src/Blocks.java`)
- Made `transactionDiff()` order-agnostic by normalizing block order before counting transactions between them. (see `src/Blocks.java`)
- Fixed the default dataset path used by `sortBlocksByNumber()` to use the correct CSV file. (see `src/Blocks.java`)
- Rewrote `calUniqMiners()` to an O(n) map-based aggregation (`LinkedHashMap`) for correctness and speed. (see `src/Blocks.java`)
- Improved `uniqFromTo()` grouping and ordering using linked maps so output matches the expected order of first appearances. (see `src/Blocks.java`)
- Added defensive exception handling around the explorer menu action that prints unique miners so CLI usage no longer crashes on I/O errors. (see `src/EthereumBlockExplorer.java`)
- Documented the throughput/reliability upgrades in `IMPROVEMENTS.md`.

### Testing
- Attempted to compile the full tree with tests using `javac -cp src src/*.java`, which failed in this environment because JUnit (`org.junit.jupiter.api`) is not available (unit test compile step skipped for now). (failure)
- Compiled core classes with `javac -cp src src/Transaction.java src/Blocks.java src/Driver.java src/EthereumBlockExplorer.java`, which completed successfully. (success)
- Performed a smoke run of the CLI using `printf '0\n' | java -cp src EthereumBlockExplorer` and observed the app load data and exit cleanly with `Successfully loaded 100 blocks.` (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0732dfc688330a11e114338e966d8)