### PR TITLE
Add analytics dashboard and command-mode UX to Ethereum explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ A blockchain is a database of transactions that is updated and shared across man
 
 For this project, we will be using a dataset of 100 blocks in the Ethereum blockchain, as well as a new dataset of transactions corresponding to the first 15 blocks in the original dataset.
 
+## Quick Start (Modern CLI)
+
+Compile core app:
+
+```bash
+javac -cp src src/Transaction.java src/Blocks.java src/Insights.java src/EthereumBlockExplorer.java
+```
+
+Run the interactive explorer:
+
+```bash
+java -cp src EthereumBlockExplorer
+```
+
+Run a zero-click analytics dashboard (fastest way to get value):
+
+```bash
+java -cp src EthereumBlockExplorer dashboard
+```
+
+Inspect a specific block directly:
+
+```bash
+java -cp src EthereumBlockExplorer block 15049311
+```
+
 ## Transaction UML
 
 <img src=./imgs/TransactionUML.PNG width=50% height=50%>

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -5,25 +5,61 @@ import java.util.Scanner;
 
 /**
  * Main application for exploring Ethereum blockchain data.
- * Provides a user-friendly command-line interface for various blockchain operations.
+ * Supports interactive mode and direct command mode.
  */
 public class EthereumBlockExplorer {
     private static Scanner scanner = new Scanner(System.in);
     private static ArrayList<Blocks> blocks = null;
-    
+
     public static void main(String[] args) {
-        System.out.println("===========================================");
-        System.out.println("   Ethereum Block Explorer v2.0");
-        System.out.println("===========================================\n");
-        
-        // Load data on startup
         loadData();
-        
+
+        if (args.length > 0) {
+            runCommandMode(args);
+            scanner.close();
+            return;
+        }
+
+        runInteractiveMode();
+        scanner.close();
+    }
+
+    private static void runCommandMode(String[] args) {
+        String command = args[0].toLowerCase();
+
+        try {
+            switch (command) {
+                case "dashboard":
+                    Insights.printDashboard(blocks, 5);
+                    break;
+                case "block":
+                    if (args.length < 2) {
+                        System.out.println("Usage: java -cp src EthereumBlockExplorer block <blockNumber>");
+                        return;
+                    }
+                    printBlockDetails(Integer.parseInt(args[1]));
+                    break;
+                default:
+                    System.out.println("Unknown command: " + command);
+                    System.out.println("Available commands: dashboard, block <blockNumber>");
+            }
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid numeric argument.");
+        } catch (Exception e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+    }
+
+    private static void runInteractiveMode() {
+        System.out.println("===========================================");
+        System.out.println("   Ethereum Block Explorer v3.0");
+        System.out.println("===========================================");
+
         boolean running = true;
         while (running) {
             displayMenu();
             int choice = getMenuChoice();
-            
+
             switch (choice) {
                 case 1:
                     viewBlockDetails();
@@ -44,6 +80,9 @@ public class EthereumBlockExplorer {
                     viewTransactionsByAddress();
                     break;
                 case 7:
+                    viewDashboard();
+                    break;
+                case 8:
                     reloadData();
                     break;
                 case 0:
@@ -53,16 +92,14 @@ public class EthereumBlockExplorer {
                 default:
                     System.out.println("\nInvalid choice. Please try again.");
             }
-            
-            if (running && choice >= 1 && choice <= 7) {
+
+            if (running && choice >= 1 && choice <= 8) {
                 System.out.println("\nPress Enter to continue...");
                 scanner.nextLine();
             }
         }
-        
-        scanner.close();
     }
-    
+
     private static void displayMenu() {
         System.out.println("\n========== MAIN MENU ==========");
         System.out.println("1. View Block Details");
@@ -71,12 +108,13 @@ public class EthereumBlockExplorer {
         System.out.println("4. View Unique Miners");
         System.out.println("5. Compare Blocks");
         System.out.println("6. View Transactions by Address");
-        System.out.println("7. Reload Data");
+        System.out.println("7. View Analytics Dashboard");
+        System.out.println("8. Reload Data");
         System.out.println("0. Exit");
         System.out.println("===============================");
         System.out.print("Enter your choice: ");
     }
-    
+
     private static int getMenuChoice() {
         try {
             return Integer.parseInt(scanner.nextLine());
@@ -84,67 +122,69 @@ public class EthereumBlockExplorer {
             return -1;
         }
     }
-    
+
     private static void loadData() {
-        System.out.println("Loading blockchain data...");
         try {
             Blocks.readFile("ethereumP1data.csv");
             Blocks.sortBlocksByNumber();
             blocks = Blocks.getBlocks();
-            System.out.println("Successfully loaded " + blocks.size() + " blocks.\n");
         } catch (FileNotFoundException e) {
             System.err.println("Error: Data file not found. Please ensure 'ethereumP1data.csv' exists.");
-            System.err.println("Exiting application...");
             System.exit(1);
         } catch (IOException e) {
             System.err.println("Error reading data file: " + e.getMessage());
-            System.err.println("Exiting application...");
             System.exit(1);
         }
     }
-    
+
     private static void reloadData() {
+        System.out.println("Reloading blockchain data...");
         loadData();
+        System.out.println("Loaded " + blocks.size() + " blocks.");
     }
-    
+
+    private static void printBlockDetails(int blockNum) throws IOException {
+        Blocks block = Blocks.getBlockByNumber(blockNum);
+
+        if (block != null) {
+            System.out.println("\n===== BLOCK DETAILS =====");
+            System.out.println("Block Number: " + block.getNumber());
+            System.out.println("Miner Address: " + block.getMiner());
+            System.out.println("Timestamp: " + block.getDate());
+            System.out.println("Transaction Count: " + block.getTransactionCount());
+            System.out.printf("Average Transaction Cost: %.8f ETH%n", block.avgTransactionCost());
+            System.out.println("=========================");
+        } else {
+            System.out.println("\nBlock not found.");
+        }
+    }
+
     private static void viewBlockDetails() {
         System.out.print("\nEnter block number: ");
         try {
-            int blockNum = Integer.parseInt(scanner.nextLine());
-            Blocks block = Blocks.getBlockByNumber(blockNum);
-            
-            if (block != null) {
-                System.out.println("\n===== BLOCK DETAILS =====");
-                System.out.println("Block Number: " + block.getNumber());
-                System.out.println("Miner Address: " + block.getMiner());
-                System.out.println("Timestamp: " + block.getDate());
-                System.out.println("Transaction Count: " + block.getTransactionCount());
-                System.out.println("=========================");
-            } else {
-                System.out.println("\nBlock not found.");
-            }
+            printBlockDetails(Integer.parseInt(scanner.nextLine()));
         } catch (NumberFormatException e) {
             System.out.println("\nInvalid block number.");
         } catch (Exception e) {
             System.err.println("\nError: " + e.getMessage());
         }
     }
-    
+
     private static void viewTransactionsByBlock() {
         System.out.print("\nEnter block number: ");
         try {
             int blockNum = Integer.parseInt(scanner.nextLine());
             Blocks block = Blocks.getBlockByNumber(blockNum);
-            
+
             if (block != null) {
                 ArrayList<Transaction> transactions = block.getTransactions();
                 System.out.println("\n===== TRANSACTIONS FOR BLOCK " + blockNum + " =====");
                 System.out.println("Total transactions: " + transactions.size());
-                
+
                 if (transactions.size() > 0) {
                     System.out.print("Show all transactions? (y/n): ");
                     String showAll = scanner.nextLine().toLowerCase();
-                    
+
                     if (showAll.equals("y")) {
                         for (Transaction t : transactions) {
                             System.out.println(t);
@@ -165,17 +205,16 @@ public class EthereumBlockExplorer {
             System.err.println("\nError: " + e.getMessage());
         }
     }
-    
+
     private static void calculateAverageTransactionCost() {
         System.out.print("\nEnter block number: ");
         try {
             int blockNum = Integer.parseInt(scanner.nextLine());
             Blocks block = Blocks.getBlockByNumber(blockNum);
-            
+
             if (block != null) {
                 double avgCost = block.avgTransactionCost();
-                System.out.printf("\nAverage transaction cost for Block %d: %.8f ETH\n", 
-                                  blockNum, avgCost);
+                System.out.printf("\nAverage transaction cost for Block %d: %.8f ETH%n", blockNum, avgCost);
             } else {
                 System.out.println("\nBlock not found.");
             }
@@ -185,7 +224,7 @@ public class EthereumBlockExplorer {
             System.err.println("\nError: " + e.getMessage());
         }
     }
-    
+
     private static void viewUniqueMiners() {
         System.out.println("\n===== UNIQUE MINERS =====");
         try {
@@ -194,28 +233,28 @@ public class EthereumBlockExplorer {
             System.err.println("\nError: " + e.getMessage());
         }
     }
-    
+
     private static void compareBlocks() {
         try {
             System.out.print("\nEnter first block number: ");
             int block1Num = Integer.parseInt(scanner.nextLine());
             System.out.print("Enter second block number: ");
             int block2Num = Integer.parseInt(scanner.nextLine());
-            
+
             Blocks block1 = Blocks.getBlockByNumber(block1Num);
             Blocks block2 = Blocks.getBlockByNumber(block2Num);
-            
+
             if (block1 != null && block2 != null) {
                 System.out.println("\n===== BLOCK COMPARISON =====");
                 System.out.println("Block difference: " + Blocks.blockDiff(block1, block2));
                 System.out.println("\nTime difference:");
                 Blocks.timeDiff(block1, block2);
-                
+
                 int transDiff = Blocks.transactionDiff(block1, block2);
                 if (transDiff >= 0) {
                     System.out.println("\nTransactions between blocks: " + transDiff);
                 } else {
-                    System.out.println("\nCannot calculate transactions between blocks (invalid order).");
+                    System.out.println("\nCannot calculate transactions between blocks.");
                 }
             } else {
                 System.out.println("\nOne or both blocks not found.");
@@ -226,13 +265,13 @@ public class EthereumBlockExplorer {
             System.err.println("\nError: " + e.getMessage());
         }
     }
-    
+
     private static void viewTransactionsByAddress() {
         System.out.print("\nEnter block number: ");
         try {
             int blockNum = Integer.parseInt(scanner.nextLine());
             Blocks block = Blocks.getBlockByNumber(blockNum);
-            
+
             if (block != null) {
                 System.out.println("\n===== TRANSACTIONS BY ADDRESS =====");
                 block.uniqFromTo();
@@ -244,5 +283,9 @@ public class EthereumBlockExplorer {
         } catch (Exception e) {
             System.err.println("\nError: " + e.getMessage());
         }
+    }
+
+    private static void viewDashboard() {
+        Insights.printDashboard(blocks, 5);
     }
 }

--- a/src/Insights.java
+++ b/src/Insights.java
@@ -1,0 +1,88 @@
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lean analytics layer that turns raw block data into actionable summary insights.
+ */
+public final class Insights {
+    private Insights() {}
+
+    public static void printDashboard(ArrayList<Blocks> blocks, int topN) {
+        if (blocks == null || blocks.isEmpty()) {
+            System.out.println("No block data loaded.");
+            return;
+        }
+
+        int totalBlocks = blocks.size();
+        long totalTransactions = 0L;
+        double totalAvgCostAcrossBlocks = 0.0;
+        int blocksWithTransactions = 0;
+        Map<String, Integer> minerFrequency = new HashMap<>();
+
+        for (Blocks block : blocks) {
+            totalTransactions += block.getTransactionCount();
+            minerFrequency.put(block.getMiner(), minerFrequency.getOrDefault(block.getMiner(), 0) + 1);
+
+            if (!block.getTransactions().isEmpty()) {
+                totalAvgCostAcrossBlocks += block.avgTransactionCost();
+                blocksWithTransactions++;
+            }
+        }
+
+        double avgTransactionsPerBlock = totalBlocks == 0 ? 0.0 : (double) totalTransactions / totalBlocks;
+        double avgCostPerActiveBlock = blocksWithTransactions == 0 ? 0.0 : totalAvgCostAcrossBlocks / blocksWithTransactions;
+
+        System.out.println("\n========== ETHEREUM DASHBOARD ==========");
+        System.out.println("Blocks loaded: " + totalBlocks);
+        System.out.println("Unique miners: " + minerFrequency.size());
+        System.out.println("Total transactions: " + totalTransactions);
+        System.out.printf("Avg transactions / block: %.2f%n", avgTransactionsPerBlock);
+        System.out.printf("Avg tx cost / active block: %.8f ETH%n", avgCostPerActiveBlock);
+
+        printTopMiners(minerFrequency, topN);
+        printTopBlocksByTransactionCount(blocks, topN);
+        printTopBlocksByAverageCost(blocks, topN);
+        System.out.println("========================================\n");
+    }
+
+    private static void printTopMiners(Map<String, Integer> minerFrequency, int topN) {
+        List<Map.Entry<String, Integer>> sorted = new ArrayList<>(minerFrequency.entrySet());
+        sorted.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+
+        System.out.println("\nTop miners by block production:");
+        for (int i = 0; i < Math.min(topN, sorted.size()); i++) {
+            Map.Entry<String, Integer> entry = sorted.get(i);
+            System.out.println((i + 1) + ". " + entry.getKey() + "  (" + entry.getValue() + " blocks)");
+        }
+    }
+
+    private static void printTopBlocksByTransactionCount(ArrayList<Blocks> blocks, int topN) {
+        ArrayList<Blocks> sorted = new ArrayList<>(blocks);
+        sorted.sort((a, b) -> Integer.compare(b.getTransactionCount(), a.getTransactionCount()));
+
+        System.out.println("\nTop blocks by transaction volume:");
+        for (int i = 0; i < Math.min(topN, sorted.size()); i++) {
+            Blocks block = sorted.get(i);
+            System.out.println((i + 1) + ". Block " + block.getNumber() + "  (" + block.getTransactionCount() + " tx)");
+        }
+    }
+
+    private static void printTopBlocksByAverageCost(ArrayList<Blocks> blocks, int topN) {
+        ArrayList<Blocks> activeBlocks = new ArrayList<>();
+        for (Blocks block : blocks) {
+            if (!block.getTransactions().isEmpty()) {
+                activeBlocks.add(block);
+            }
+        }
+
+        activeBlocks.sort((a, b) -> Double.compare(b.avgTransactionCost(), a.avgTransactionCost()));
+
+        System.out.println("\nTop blocks by average transaction cost:");
+        for (int i = 0; i < Math.min(topN, activeBlocks.size()); i++) {
+            Blocks block = activeBlocks.get(i);
+            System.out.printf("%d. Block %d  (%.8f ETH)%n", i + 1, block.getNumber(), block.avgTransactionCost());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide immediate, actionable value from the dataset instead of only raw browsing. 
- Give power users a zero-click way to get signals and allow quick block inspection from the CLI. 
- Modernize the UX so the tool is useful in seconds for analytics and debugging.

### Description
- Add a new `Insights` module (`src/Insights.java`) that computes and prints a concise dashboard with totals, average metrics, and ranked lists for miners, top-transaction blocks, and high-average-cost blocks. 
- Upgrade `EthereumBlockExplorer` (`src/EthereumBlockExplorer.java`) to support command mode (`dashboard`, `block <blockNumber>`) and integrate the dashboard into the interactive menu, and include average transaction cost in block detail output. 
- Add a short Quick Start to `README.md` with the modern CLI compile/run commands and the zero-click `dashboard` path for immediate value. 
- Keep the interactive explorer intact while enabling a fast path for analytics and direct queries.

### Testing
- Compiled the core app with `javac -cp src src/Transaction.java src/Blocks.java src/Insights.java src/EthereumBlockExplorer.java src/Driver.java` and the compile completed successfully. 
- Ran the zero-click analytics with `java -cp src EthereumBlockExplorer dashboard` and verified the dashboard printed expected summaries and top lists (command completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07dc97fb08330b54902c176b72bb4)