### PR TITLE
Add actionable 'brief' command and embed action brief into reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Generate a lean Markdown intelligence report (great for sharing):
 java -cp src EthereumBlockExplorer report ethereum-report.md
 ```
 
+Run a decisive action brief (fast, executive summary + next moves):
+
+```bash
+java -cp src EthereumBlockExplorer brief
+```
+
+
 ## Transaction UML
 
 <img src=./imgs/TransactionUML.PNG width=50% height=50%>

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -35,6 +35,9 @@ public class EthereumBlockExplorer {
                 case "dashboard":
                     Insights.printDashboard(blocks, 5);
                     break;
+                case "brief":
+                    Insights.printActionBrief(blocks, 5);
+                    break;
                 case "report":
                     writeReport(args.length >= 2 ? args[1] : "ethereum-report.md");
                     break;
@@ -47,7 +50,7 @@ public class EthereumBlockExplorer {
                     break;
                 default:
                     System.out.println("Unknown command: " + command);
-                    System.out.println("Available commands: dashboard, report [file], block <blockNumber>");
+                    System.out.println("Available commands: dashboard, brief, report [file], block <blockNumber>");
             }
         } catch (NumberFormatException e) {
             System.out.println("Invalid numeric argument.");
@@ -92,6 +95,9 @@ public class EthereumBlockExplorer {
                     exportReport();
                     break;
                 case 9:
+                    viewActionBrief();
+                    break;
+                case 10:
                     reloadData();
                     break;
                 case 0:
@@ -102,7 +108,7 @@ public class EthereumBlockExplorer {
                     System.out.println("\nInvalid choice. Please try again.");
             }
 
-            if (running && choice >= 1 && choice <= 9) {
+            if (running && choice >= 1 && choice <= 10) {
                 System.out.println("\nPress Enter to continue...");
                 scanner.nextLine();
             }
@@ -119,7 +125,8 @@ public class EthereumBlockExplorer {
         System.out.println("6. View Transactions by Address");
         System.out.println("7. View Analytics Dashboard");
         System.out.println("8. Export Lean Markdown Report");
-        System.out.println("9. Reload Data");
+        System.out.println("9. View Action Brief");
+        System.out.println("10. Reload Data");
         System.out.println("0. Exit");
         System.out.println("===============================");
         System.out.print("Enter your choice: ");
@@ -310,6 +317,10 @@ public class EthereumBlockExplorer {
         } catch (IOException e) {
             System.err.println("Failed to write report: " + e.getMessage());
         }
+    }
+
+    private static void viewActionBrief() {
+        Insights.printActionBrief(blocks, 5);
     }
 
     private static void writeReport(String filePath) throws IOException {


### PR DESCRIPTION
### Motivation
- Provide a single, decision-grade output instead of only raw statistics so operators can act quickly. 
- Surface high-value signals (miner concentration, cost outliers, busiest block, top spenders) and give concise next moves.

### Description
- Added `Insights.buildActionBrief(...)` and `Insights.printActionBrief(...)` to produce an executive action brief that computes miner concentration, busiest block, highest average-cost block, cost outliers, top spenders, and recommended next moves.
- Wired the action brief into the Markdown report by embedding the result of `buildActionBrief(...)` in `Insights.buildReport(...)`.
- Exposed the new feature via CLI and interactive menu: added a `brief` command and a "View Action Brief" menu item in `EthereumBlockExplorer` with a `viewActionBrief()` helper.
- Updated `README.md` Quick Start to advertise the new `brief` workflow.

### Testing
- Compiled core sources with `javac -cp src src/Transaction.java src/Blocks.java src/Insights.java src/EthereumBlockExplorer.java`, which completed successfully.
- Executed `java -cp src EthereumBlockExplorer brief` to print the action brief, which produced the expected executive summary output (success).
- Generated a Markdown report with `java -cp src EthereumBlockExplorer report /tmp/ethereum-report.md` and inspected the file to confirm the action brief was embedded (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0801cf8508330a708c20fe312aa7e)