### PR TITLE
Add address intelligence mode to EthereumBlockExplorer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Run a decisive action brief (fast, executive summary + next moves):
 java -cp src EthereumBlockExplorer brief
 ```
 
+Get instant intelligence on any wallet in the dataset (counterparties, net flow, hot blocks):
+
+```bash
+java -cp src EthereumBlockExplorer address 0x58a5b1a1c67e984247a0c78f2875b0f9c781b64f
+```
+
 
 ## Transaction UML
 

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -48,9 +48,16 @@ public class EthereumBlockExplorer {
                     }
                     printBlockDetails(Integer.parseInt(args[1]));
                     break;
+                case "address":
+                    if (args.length < 2) {
+                        System.out.println("Usage: java -cp src EthereumBlockExplorer address <0xAddress>");
+                        return;
+                    }
+                    Insights.printAddressIntel(blocks, args[1], 5);
+                    break;
                 default:
                     System.out.println("Unknown command: " + command);
-                    System.out.println("Available commands: dashboard, brief, report [file], block <blockNumber>");
+                    System.out.println("Available commands: dashboard, brief, report [file], block <blockNumber>, address <0xAddress>");
             }
         } catch (NumberFormatException e) {
             System.out.println("Invalid numeric argument.");
@@ -98,6 +105,9 @@ public class EthereumBlockExplorer {
                     viewActionBrief();
                     break;
                 case 10:
+                    viewAddressIntel();
+                    break;
+                case 11:
                     reloadData();
                     break;
                 case 0:
@@ -108,7 +118,7 @@ public class EthereumBlockExplorer {
                     System.out.println("\nInvalid choice. Please try again.");
             }
 
-            if (running && choice >= 1 && choice <= 10) {
+            if (running && choice >= 1 && choice <= 11) {
                 System.out.println("\nPress Enter to continue...");
                 scanner.nextLine();
             }
@@ -126,7 +136,8 @@ public class EthereumBlockExplorer {
         System.out.println("7. View Analytics Dashboard");
         System.out.println("8. Export Lean Markdown Report");
         System.out.println("9. View Action Brief");
-        System.out.println("10. Reload Data");
+        System.out.println("10. Address Intel");
+        System.out.println("11. Reload Data");
         System.out.println("0. Exit");
         System.out.println("===============================");
         System.out.print("Enter your choice: ");
@@ -321,6 +332,12 @@ public class EthereumBlockExplorer {
 
     private static void viewActionBrief() {
         Insights.printActionBrief(blocks, 5);
+    }
+
+    private static void viewAddressIntel() {
+        System.out.print("\nEnter Ethereum address (0x...): ");
+        String address = scanner.nextLine().trim();
+        Insights.printAddressIntel(blocks, address, 5);
     }
 
     private static void writeReport(String filePath) throws IOException {


### PR DESCRIPTION
### Motivation
- The project provided block-level views but lacked fast, actionable wallet-level intelligence for triage and investigation.
- Add a focused, minimal feature that surfaces top counterparties, net flow, and hot blocks for any address to provide immediate real-world value.

### Description
- Add `address` command-mode in `EthereumBlockExplorer` so users can run `java -cp src EthereumBlockExplorer address <0xAddress>` to get a concise wallet brief. (Updated `src/EthereumBlockExplorer.java`.)
- Add an interactive menu entry `Address Intel` with `viewAddressIntel()` to run the same flow from the UI. (Updated `src/EthereumBlockExplorer.java`.)
- Implement `Insights.buildAddressIntel(...)` and `Insights.printAddressIntel(...)` which validate the address and compute inbound/outbound counts and ETH totals, net flow, active block range, top counterparties, busiest blocks, and next-action recommendations. (Updated `src/Insights.java`.)
- Document the new command in `README.md` with an example so the feature is discoverable and immediately usable.

### Testing
- Build: ran `javac -cp src src/Transaction.java src/Blocks.java src/Insights.java src/EthereumBlockExplorer.java src/Driver.java` and the compilation succeeded.
- Runtime smoke test: executed `java -cp src EthereumBlockExplorer address 0x58a5b1a1c67e984247a0c78f2875b0f9c781b64f` and the command produced the expected address intelligence output (inbound/outbound counts, counterparties, busiest blocks).
- Note: existing unit tests in `src/TestBlocks.java` and `src/TestTransaction.java` were not re-run in this change; no unit test failures were observed during compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a081ccd41c8330b0cb096c57a35db8)