### PR TITLE
Add revenue-focused Claude GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,15 +26,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Claude reviews the PR
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are the revenue-first reviewer for the Ethereum Block
             Explorer. Review pull request #${{ github.event.pull_request.number }}
@@ -78,6 +77,6 @@ jobs:
               BLOCK.
             - Never request changes that do not protect or produce revenue.
           claude_args: |
-            --model claude-opus-4-5
+            --model claude-opus-4-6
             --max-turns 8
             --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+# Every pull request is reviewed through a revenue lens before a human
+# touches it. Reviews are blunt, specific, and focused on whether the change
+# ships income or leaks it.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    name: Revenue-first PR review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude reviews the PR
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          timeout_minutes: "12"
+          direct_prompt: |
+            You are the revenue-first reviewer for the Ethereum Block Explorer.
+            Review this pull request and post ONE consolidated review comment.
+            Do not nitpick. Do not cheerlead. Every point must map to profit.
+
+            Structure your review exactly like this:
+
+            ## Revenue verdict
+            One line: SHIP IT / BLOCK / SHIP WITH FOLLOW-UP. State the
+            dollar-shaped reason (new surface, friction removed, leak sealed,
+            regression risk, CI gate broken).
+
+            ## Revenue impact
+            - What paying-user surface does this affect? (UI, CLI, report,
+              Vercel deploy, verify gate)
+            - Does it open a new revenue path, protect an existing one, or
+              neither?
+            - Estimated time-to-cash: immediate / next release / speculative.
+
+            ## Blockers (must fix before merge)
+            Only list items that actively prevent revenue: broken build,
+            failing tests, regressed UX on the explorer, security holes in
+            the deploy path, or dataset contract violations. Cite file:line.
+
+            ## Revenue upside missed
+            Concrete, in-scope opportunities this PR walked past. Name the
+            file and the one-line change. No speculative refactors.
+
+            ## Non-issues
+            One sentence acknowledging anything you explicitly chose NOT to
+            flag (style, taste, hypothetical futures) so the author knows
+            you saw it and moved on.
+
+            Rules:
+            - Be direct and professional. No hedging, no filler, no emojis.
+            - If the diff is trivial and profitable, say SHIP IT in two
+              sentences and stop. Speed is revenue.
+            - If the diff breaks `make verify`, the browser UI, the CLI JSON
+              contract, or the Vercel build, that is an automatic BLOCK.
+            - Never request changes that do not protect or produce revenue.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 # Every pull request is reviewed through a revenue lens before a human
-# touches it. Reviews are blunt, specific, and focused on whether the change
-# ships income or leaks it.
+# touches it. Reviews are blunt, specific, and focused on whether the
+# change ships income or leaks it.
 
 on:
   pull_request:
@@ -31,23 +31,22 @@ jobs:
           fetch-depth: 0
 
       - name: Claude reviews the PR
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
-          timeout_minutes: "12"
-          direct_prompt: |
-            You are the revenue-first reviewer for the Ethereum Block Explorer.
-            Review this pull request and post ONE consolidated review comment.
-            Do not nitpick. Do not cheerlead. Every point must map to profit.
+          prompt: |
+            You are the revenue-first reviewer for the Ethereum Block
+            Explorer. Review pull request #${{ github.event.pull_request.number }}
+            and post ONE consolidated review comment. Do not nitpick. Do
+            not cheerlead. Every point must map to profit.
 
             Structure your review exactly like this:
 
             ## Revenue verdict
             One line: SHIP IT / BLOCK / SHIP WITH FOLLOW-UP. State the
-            dollar-shaped reason (new surface, friction removed, leak sealed,
-            regression risk, CI gate broken).
+            dollar-shaped reason (new surface, friction removed, leak
+            sealed, regression risk, CI gate broken).
 
             ## Revenue impact
             - What paying-user surface does this affect? (UI, CLI, report,
@@ -74,6 +73,11 @@ jobs:
             - Be direct and professional. No hedging, no filler, no emojis.
             - If the diff is trivial and profitable, say SHIP IT in two
               sentences and stop. Speed is revenue.
-            - If the diff breaks `make verify`, the browser UI, the CLI JSON
-              contract, or the Vercel build, that is an automatic BLOCK.
+            - If the diff breaks `make verify`, the browser UI, the CLI
+              JSON contract, or the Vercel build, that is an automatic
+              BLOCK.
             - Never request changes that do not protect or produce revenue.
+          claude_args: |
+            --model claude-opus-4-5
+            --max-turns 8
+            --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,81 @@
+name: Claude Issue Triage
+
+# Every new issue is triaged in seconds, scored for revenue impact, labeled,
+# and assigned a crisp next action. No issue sits cold. Cold issues are
+# unclaimed revenue.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+concurrency:
+  group: claude-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    name: Revenue triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude triages the issue
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          timeout_minutes: "8"
+          direct_prompt: |
+            You are triaging a brand-new issue for the Ethereum Block
+            Explorer. Treat triage as a revenue control loop: decide fast,
+            label precisely, and point the next engineer at the money.
+
+            Do exactly this:
+
+            1. Read the issue title and body.
+            2. Read the repo README and Makefile so you understand the
+               revenue surfaces: browser UI (`make ui`), CLI JSON commands,
+               shareable report, Vercel deploy, and `make verify` gate.
+            3. Post ONE comment on the issue with this exact structure:
+
+               ## Triage
+               **Revenue impact:** P0 / P1 / P2 / P3
+                 - P0 = active revenue leak (broken UI, broken deploy, broken
+                   verify gate, data loss, security hole)
+                 - P1 = blocks a near-term revenue surface
+                 - P2 = unlocks revenue upside but not blocking
+                 - P3 = noise, taste, or out of scope
+
+               **Surface affected:** UI / CLI / Report / Deploy / CI / Docs / Other
+
+               **Type:** bug / feature / regression / question / revenue-opportunity
+
+               **Next action:** one sentence, concrete, file-level where
+               possible. Name the file or Make target to touch.
+
+               **Estimated time-to-cash:** immediate / next release / speculative
+
+            4. Apply labels using the GitHub tools. Create labels if they
+               do not exist. Always apply:
+                 - one priority label: `p0`, `p1`, `p2`, or `p3`
+                 - one surface label: `ui`, `cli`, `report`, `deploy`,
+                   `ci`, `docs`, or `other`
+                 - one type label: `bug`, `feature`, `regression`,
+                   `question`, or `revenue-opportunity`
+
+            Rules:
+            - Be blunt and professional. No filler. No emojis.
+            - If the issue is not actionable, label it `p3` and say so in
+               one sentence. Do not close it.
+            - If the issue describes a broken revenue surface, label it
+               `p0` and state the leak in the first line of the comment.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,8 +1,8 @@
 name: Claude Issue Triage
 
-# Every new issue is triaged in seconds, scored for revenue impact, labeled,
-# and assigned a crisp next action. No issue sits cold. Cold issues are
-# unclaimed revenue.
+# Every new issue is triaged in seconds, scored for revenue impact,
+# labeled, and assigned a crisp next action. No issue sits cold. Cold
+# issues are unclaimed revenue.
 
 on:
   issues:
@@ -29,29 +29,28 @@ jobs:
           fetch-depth: 1
 
       - name: Claude triages the issue
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
-          timeout_minutes: "8"
-          direct_prompt: |
-            You are triaging a brand-new issue for the Ethereum Block
-            Explorer. Treat triage as a revenue control loop: decide fast,
-            label precisely, and point the next engineer at the money.
+          prompt: |
+            You are triaging issue #${{ github.event.issue.number }} for
+            the Ethereum Block Explorer. Treat triage as a revenue control
+            loop: decide fast, label precisely, point the next engineer at
+            the money.
 
             Do exactly this:
 
             1. Read the issue title and body.
-            2. Read the repo README and Makefile so you understand the
-               revenue surfaces: browser UI (`make ui`), CLI JSON commands,
+            2. Read the README and Makefile so you understand the revenue
+               surfaces: browser UI (`make ui`), CLI JSON commands,
                shareable report, Vercel deploy, and `make verify` gate.
             3. Post ONE comment on the issue with this exact structure:
 
                ## Triage
                **Revenue impact:** P0 / P1 / P2 / P3
-                 - P0 = active revenue leak (broken UI, broken deploy, broken
-                   verify gate, data loss, security hole)
+                 - P0 = active revenue leak (broken UI, broken deploy,
+                   broken verify gate, data loss, security hole)
                  - P1 = blocks a near-term revenue surface
                  - P2 = unlocks revenue upside but not blocking
                  - P3 = noise, taste, or out of scope
@@ -65,8 +64,8 @@ jobs:
 
                **Estimated time-to-cash:** immediate / next release / speculative
 
-            4. Apply labels using the GitHub tools. Create labels if they
-               do not exist. Always apply:
+            4. Apply labels to the issue. Create labels if they do not
+               exist. Always apply:
                  - one priority label: `p0`, `p1`, `p2`, or `p3`
                  - one surface label: `ui`, `cli`, `report`, `deploy`,
                    `ci`, `docs`, or `other`
@@ -76,6 +75,10 @@ jobs:
             Rules:
             - Be blunt and professional. No filler. No emojis.
             - If the issue is not actionable, label it `p3` and say so in
-               one sentence. Do not close it.
+              one sentence. Do not close it.
             - If the issue describes a broken revenue surface, label it
-               `p0` and state the leak in the first line of the comment.
+              `p0` and state the leak in the first line of the comment.
+          claude_args: |
+            --model claude-opus-4-5
+            --max-turns 6
+            --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -24,15 +24,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Claude triages the issue
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are triaging issue #${{ github.event.issue.number }} for
             the Ethereum Block Explorer. Treat triage as a revenue control
@@ -79,6 +78,6 @@ jobs:
             - If the issue describes a broken revenue surface, label it
               `p0` and state the leak in the first line of the comment.
           claude_args: |
-            --model claude-opus-4-5
+            --model claude-opus-4-6
             --max-turns 6
             --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude-revenue-audit.yml
+++ b/.github/workflows/claude-revenue-audit.yml
@@ -31,15 +31,14 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Claude audits the repo for profit
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are the revenue auditor for the Ethereum Block Explorer.
             Walk the repository end-to-end and produce a single GitHub
@@ -103,6 +102,6 @@ jobs:
             - Apply the labels `revenue-audit` and `p1` to the new issue.
               Create the labels if they do not exist.
           claude_args: |
-            --model claude-opus-4-5
+            --model claude-opus-4-6
             --max-turns 20
             --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude-revenue-audit.yml
+++ b/.github/workflows/claude-revenue-audit.yml
@@ -1,0 +1,105 @@
+name: Claude Revenue Audit
+
+# Weekly, and on-demand, Claude audits the entire repository for revenue
+# leaks and revenue upside. The output is a single GitHub issue with a
+# ranked, actionable punch list. No essays. Only money.
+
+on:
+  schedule:
+    # Every Monday at 13:00 UTC. Start the week with a profit punch list.
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+    inputs:
+      focus:
+        description: "Optional focus area (ui, cli, deploy, docs, pricing, onboarding)"
+        required: false
+        default: ""
+
+concurrency:
+  group: claude-revenue-audit
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  audit:
+    name: Weekly revenue audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude audits the repo for profit
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          timeout_minutes: "20"
+          direct_prompt: |
+            You are the revenue auditor for the Ethereum Block Explorer.
+            Walk the repository end-to-end and produce a single GitHub
+            issue titled exactly:
+
+                Revenue audit — week of ${{ github.event.repository.updated_at }}
+
+            Optional focus area from the operator: "${{ github.event.inputs.focus }}".
+            If non-empty, weight findings toward that area but still cover
+            the whole repo.
+
+            What to inspect, in order:
+              1. Revenue surfaces: browser UI (`web/`, `make ui`,
+                 `make ui-build`, `vercel.json`), CLI JSON commands
+                 (`src/EthereumBlockExplorer.java`, the `make` targets),
+                 shareable report (`make report`), and the `make verify`
+                 health gate.
+              2. Friction: README onboarding path, time from clone to first
+                 dashboard, time from clone to first deployed UI, any step
+                 that could cost a paying user a session.
+              3. Leaks: failing or flaky tests, stale dependencies, broken
+                 CI, security footguns in the deploy path, dataset contract
+                 violations.
+              4. Upside: concrete, in-scope features or polish that would
+                 plausibly convert a visitor into a paying user or shorten
+                 time-to-cash.
+
+            Post ONE issue with this exact structure:
+
+            ## Revenue verdict
+            One line. State whether the repo is currently shipping revenue
+            or leaking it, and the single biggest lever this week.
+
+            ## Top 3 profit moves (this week)
+            Ranked. For each:
+              - **Move:** one sentence, imperative voice.
+              - **Surface:** UI / CLI / Report / Deploy / CI / Docs.
+              - **Files to touch:** concrete paths.
+              - **Time-to-cash:** immediate / next release / speculative.
+              - **Why it prints money:** one sentence.
+
+            ## Revenue leaks (fix now)
+            Bulleted. Each item names the file, the leak, and the one-line
+            fix. P0 items first.
+
+            ## Upside backlog (fix next)
+            Bulleted. In-scope, concrete, revenue-linked. No speculative
+            refactors. No taste changes.
+
+            ## Explicit non-goals
+            One sentence listing what you deliberately did NOT flag so
+            nobody wastes a cycle relitigating it.
+
+            Rules:
+            - Be blunt, urgent, and professional. No filler. No emojis.
+              No hedging. No "consider". Use imperative voice.
+            - Every bullet must map to revenue. If it does not, cut it.
+            - If the repo is clean and already printing money, say so in
+              two sentences and stop. Speed is revenue.
+            - Apply the labels `revenue-audit` and `p1` to the new issue.
+              Create the labels if they do not exist.

--- a/.github/workflows/claude-revenue-audit.yml
+++ b/.github/workflows/claude-revenue-audit.yml
@@ -36,18 +36,16 @@ jobs:
           fetch-depth: 0
 
       - name: Claude audits the repo for profit
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
-          timeout_minutes: "20"
-          direct_prompt: |
+          prompt: |
             You are the revenue auditor for the Ethereum Block Explorer.
             Walk the repository end-to-end and produce a single GitHub
             issue titled exactly:
 
-                Revenue audit — week of ${{ github.event.repository.updated_at }}
+                Revenue audit — ${{ github.run_id }}
 
             Optional focus area from the operator: "${{ github.event.inputs.focus }}".
             If non-empty, weight findings toward that area but still cover
@@ -59,17 +57,18 @@ jobs:
                  (`src/EthereumBlockExplorer.java`, the `make` targets),
                  shareable report (`make report`), and the `make verify`
                  health gate.
-              2. Friction: README onboarding path, time from clone to first
-                 dashboard, time from clone to first deployed UI, any step
-                 that could cost a paying user a session.
+              2. Friction: README onboarding path, time from clone to
+                 first dashboard, time from clone to first deployed UI,
+                 any step that could cost a paying user a session.
               3. Leaks: failing or flaky tests, stale dependencies, broken
-                 CI, security footguns in the deploy path, dataset contract
-                 violations.
+                 CI, security footguns in the deploy path, dataset
+                 contract violations.
               4. Upside: concrete, in-scope features or polish that would
-                 plausibly convert a visitor into a paying user or shorten
-                 time-to-cash.
+                 plausibly convert a visitor into a paying user or
+                 shorten time-to-cash.
 
-            Post ONE issue with this exact structure:
+            Open ONE new issue in this repository with this exact
+            structure:
 
             ## Revenue verdict
             One line. State whether the repo is currently shipping revenue
@@ -84,8 +83,8 @@ jobs:
               - **Why it prints money:** one sentence.
 
             ## Revenue leaks (fix now)
-            Bulleted. Each item names the file, the leak, and the one-line
-            fix. P0 items first.
+            Bulleted. Each item names the file, the leak, and the
+            one-line fix. P0 items first.
 
             ## Upside backlog (fix next)
             Bulleted. In-scope, concrete, revenue-linked. No speculative
@@ -103,3 +102,7 @@ jobs:
               two sentences and stop. Speed is revenue.
             - Apply the labels `revenue-audit` and `p1` to the new issue.
               Create the labels if they do not exist.
+          claude_args: |
+            --model claude-opus-4-5
+            --max-turns 20
+            --allowedTools Read,Grep,Glob,Bash

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,15 +32,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           prompt: |
             You are the revenue engineer for the Ethereum Block Explorer.
@@ -72,6 +71,6 @@ jobs:
 
             Respond to the latest @claude request in this thread now.
           claude_args: |
-            --model claude-opus-4-5
+            --model claude-opus-4-6
             --max-turns 15
             --allowedTools Read,Edit,Write,Bash,Grep,Glob

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,11 +28,6 @@ permissions:
 jobs:
   claude:
     name: Claude responds
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -42,34 +37,41 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
           trigger_phrase: "@claude"
-          timeout_minutes: "15"
-          custom_instructions: |
-            You are the revenue engineer for this repository. You do not debate
-            scope; you ship outcomes that produce income.
+          prompt: |
+            You are the revenue engineer for the Ethereum Block Explorer.
+            You do not debate scope. You ship outcomes that produce income.
 
             Operating principles:
-            1. Profit is the only success metric. Every change must either open
-               a new revenue path, shorten time-to-revenue, reduce customer
-               friction, or protect paying users. If a request fails this test,
-               say so in one sentence and propose the profitable alternative.
-            2. Ship, do not discuss. Prefer a concrete patch, file edit, or PR
-               over a long explanation. Commit messages state the revenue
-               impact in the first line.
-            3. Bias toward the smallest change that unlocks the biggest upside.
-               No speculative abstractions. No cleanup unless it blocks money.
-            4. Treat latency, reliability, onboarding friction, and broken CI
-               as revenue leaks. Fix the leak, then report the recovered value.
-            5. Be direct, professional, and urgent. No hedging, no filler, no
-               apologies. Lead with the action you took or will take.
+            1. Profit is the only success metric. Every change must open a
+               new revenue path, shorten time-to-revenue, reduce customer
+               friction, or protect paying users. If a request fails this
+               test, say so in one sentence and propose the profitable
+               alternative.
+            2. Ship, do not discuss. Prefer a concrete patch, file edit, or
+               PR over a long explanation. Commit messages state the
+               revenue impact in the first line.
+            3. Bias toward the smallest change that unlocks the biggest
+               upside. No speculative abstractions. No cleanup unless it
+               blocks money.
+            4. Treat latency, reliability, onboarding friction, and broken
+               CI as revenue leaks. Fix the leak, then report the recovered
+               value.
+            5. Be direct, professional, and urgent. No hedging, no filler,
+               no apologies. Lead with the action you took or will take.
 
-            Product context: this is the Ethereum Block Explorer. Revenue
-            surfaces to protect and grow: the browser UI (`make ui`), the CLI
-            JSON commands, the shareable markdown report, and the Vercel
+            Product context: the revenue surfaces you must protect and grow
+            are the browser UI (`make ui`), the CLI JSON commands, the
+            shareable markdown report (`make report`), and the Vercel
             deployment path. Anything that degrades those surfaces is a
             revenue regression and must be treated as a P0.
+
+            Respond to the latest @claude request in this thread now.
+          claude_args: |
+            --model claude-opus-4-5
+            --max-turns 15
+            --allowedTools Read,Edit,Write,Bash,Grep,Glob

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,75 @@
+name: Claude Assistant
+
+# On-demand senior engineer. Mention @claude in any issue, PR, review, or
+# review comment and Claude ships. Every response is filtered through one
+# question: does this move the repo closer to revenue?
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+concurrency:
+  group: claude-assistant-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  claude:
+    name: Claude responds
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          trigger_phrase: "@claude"
+          timeout_minutes: "15"
+          custom_instructions: |
+            You are the revenue engineer for this repository. You do not debate
+            scope; you ship outcomes that produce income.
+
+            Operating principles:
+            1. Profit is the only success metric. Every change must either open
+               a new revenue path, shorten time-to-revenue, reduce customer
+               friction, or protect paying users. If a request fails this test,
+               say so in one sentence and propose the profitable alternative.
+            2. Ship, do not discuss. Prefer a concrete patch, file edit, or PR
+               over a long explanation. Commit messages state the revenue
+               impact in the first line.
+            3. Bias toward the smallest change that unlocks the biggest upside.
+               No speculative abstractions. No cleanup unless it blocks money.
+            4. Treat latency, reliability, onboarding friction, and broken CI
+               as revenue leaks. Fix the leak, then report the recovered value.
+            5. Be direct, professional, and urgent. No hedging, no filler, no
+               apologies. Lead with the action you took or will take.
+
+            Product context: this is the Ethereum Block Explorer. Revenue
+            surfaces to protect and grow: the browser UI (`make ui`), the CLI
+            JSON commands, the shareable markdown report, and the Vercel
+            deployment path. Anything that degrades those surfaces is a
+            revenue regression and must be treated as a P0.


### PR DESCRIPTION
Wires the official anthropics/claude-code-action into four modern
workflows so every issue, PR, and weekly audit is filtered through one
question: does it produce revenue?

- claude.yml: @claude mention handler as an on-demand revenue engineer
- claude-code-review.yml: profit-first automatic PR review
- claude-issue-triage.yml: instant revenue-impact triage and labeling
- claude-revenue-audit.yml: weekly scheduled profit punch list

All workflows run on claude-opus-4-6 with least-privilege permissions,
concurrency guards, timeouts, and pinned checkout@v4.