### PR TITLE
Harden CSV ingestion and runtime setup (quote-aware parser, UI hardening)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Ethereum Block Explorer local runtime settings.
+# Copy this file to .env only when you need to override defaults.
+# No secrets are required for the bundled CSV explorer.
+
+# Port used by `make ui` for the static browser explorer.
+UI_PORT=4173

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL := /bin/sh
 .DEFAULT_GOAL := help
+MAKEFLAGS += --no-print-directory
+
+-include .env
 
 # Ethereum Block Explorer v5.0
 
@@ -15,6 +18,7 @@ TEST_BINDIR = $(BINDIR)/test-classes
 JUNIT_VERSION = 1.10.2
 JUNIT_JAR = $(TOOLSDIR)/junit-platform-console-standalone-$(JUNIT_VERSION).jar
 REPORT_FILE = ethereum-report.md
+UI_PORT ?= 4173
 
 .PHONY: help build compile run run-json dashboard block address brief network anomalies miners report clean check-java check-junit test verify ui ui-build ui-serve ui-clean ui-smoke cli-smoke check-python check-ui-data check-node
 
@@ -55,6 +59,7 @@ help:
 	@echo "  - The vendored JUnit runner in $(TOOLSDIR)/"
 	@echo "  - Dataset files in the repo root: ethereumP1data.csv and ethereumtransactions1.csv"
 	@echo "  - Node.js for 'make cli-smoke', 'make ui-smoke', and 'make verify'"
+	@echo "  - Playwright browser binaries via 'npx playwright install chromium'"
 	@echo "  - Python 3 to serve the browser UI with 'make ui'"
 
 build: compile
@@ -114,15 +119,15 @@ ui-build: check-ui-data
 	@cp web/index.html web/app.css web/app.js web/favicon.svg ethereumP1data.csv ethereumtransactions1.csv web/dist/
 
 ui-serve: check-python ui-build
-	@echo "Serving visual explorer at http://localhost:4173"
-	@python3 -m http.server 4173 -d web/dist
+	@echo "Serving visual explorer at http://localhost:$(UI_PORT)"
+	@python3 -m http.server $(UI_PORT) -d web/dist
 
 ui-clean:
 	@rm -rf web/dist
 
 ui-smoke: ui-build check-node
 	@if [ ! -d node_modules/playwright ]; then \
-		echo "Browser smoke dependencies missing. Run 'npm ci', then rerun 'make ui-smoke'."; \
+		echo "Browser smoke dependencies missing. Run 'npm ci' and 'npx playwright install chromium', then rerun 'make ui-smoke'."; \
 		exit 1; \
 	fi
 	@node scripts/ui_smoke.mjs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Explore a 100-block Ethereum dataset in a lean browser UI, with fast block, address, dashboard, network, anomaly, and report workflows.
 
-The browser UI needs the dataset files [`ethereumP1data.csv`](./ethereumP1data.csv) and [`ethereumtransactions1.csv`](./ethereumtransactions1.csv) in the repo root plus Python 3 for `make ui`. CLI commands and tests also need a working Java runtime and JDK.
+The browser UI needs the dataset files [`ethereumP1data.csv`](./ethereumP1data.csv) and [`ethereumtransactions1.csv`](./ethereumtransactions1.csv) in the repo root plus Python 3 for `make ui`. CLI commands and tests also need a working Java runtime and JDK. Copy [`.env.example`](./.env.example) to `.env` only when you want to override local defaults such as `UI_PORT`.
 
 ## Start Here
 
@@ -74,7 +74,7 @@ make report
 | `make ui-clean` | Remove generated browser preview files |
 
 `make test` uses the vendored JUnit console runner in the repo, so it does not need to fetch test tooling before it runs.
-`make cli-smoke` uses Node.js plus the normal CLI prerequisites: the CSV dataset files and a working Java runtime and JDK. `make ui-smoke` uses Node.js plus Playwright after `npm ci`.
+`make cli-smoke` uses Node.js plus the normal CLI prerequisites: the CSV dataset files and a working Java runtime and JDK. `make ui-smoke` uses Node.js plus Playwright after `npm ci` and a Chromium browser install with `npx playwright install chromium`.
 `make verify` runs the same local contract as CI: the JUnit suite, the CLI smoke checks, and the browser build plus smoke path.
 
 ## Browser UI
@@ -84,6 +84,8 @@ The browser UI is a static surface built from the repo's CSV files:
 ```bash
 make ui
 ```
+
+To use a different local port, copy `.env.example` to `.env` and set `UI_PORT`.
 
 Use it when you want one lean visual workspace for:
 
@@ -105,7 +107,7 @@ It stays focused on the core jobs: dashboard, block, address, network, report, a
 
 ## Repo Notes
 
-- The default dataset contract is CSV-based: [`ethereumP1data.csv`](./ethereumP1data.csv) and [`ethereumtransactions1.csv`](./ethereumtransactions1.csv).
+- The default dataset contract is CSV-based: [`ethereumP1data.csv`](./ethereumP1data.csv) and [`ethereumtransactions1.csv`](./ethereumtransactions1.csv). Both Java and browser ingestion use quote-aware CSV parsing so commas inside exported fields do not shift columns.
 - Generated artifacts such as `.class` files and Javadoc output are not part of the supported product surface.
 - [`vercel.json`](./vercel.json) reuses `make ui-build` and publishes `web/dist/` for Vercel deployments.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "ethereum-block-explorer",
       "devDependencies": {
-        "playwright": "^1.54.2"
+        "playwright": "^1.59.1"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "ethereum-block-explorer",
   "private": true,
   "scripts": {
-    "ui:smoke": "node scripts/ui_smoke.mjs"
+    "ui:smoke": "node scripts/ui_smoke.mjs",
+    "ui:install-browsers": "playwright install chromium"
   },
   "devDependencies": {
-    "playwright": "^1.54.2"
+    "playwright": "^1.59.1"
   }
 }

--- a/scripts/ui_smoke.mjs
+++ b/scripts/ui_smoke.mjs
@@ -1,7 +1,7 @@
 import { createReadStream, existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import http from "node:http";
-import { extname, normalize, resolve } from "node:path";
+import { extname, normalize, relative, resolve, sep } from "node:path";
 import { chromium } from "playwright";
 
 const root = resolve(process.cwd(), "web/dist");
@@ -32,7 +32,8 @@ function startStaticServer(directory) {
     }
 
     const filePath = resolve(directory, "." + normalize(relativePath));
-    if (!filePath.startsWith(directory)) {
+    const relativeFilePath = relative(directory, filePath);
+    if (relativeFilePath.startsWith(".." + sep) || relativeFilePath === ".." || relativeFilePath === "") {
       response.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
       response.end("Forbidden");
       return;

--- a/src/Blocks.java
+++ b/src/Blocks.java
@@ -287,8 +287,8 @@ public class Blocks implements Comparable<Blocks> {
 				lineNumber++;
 				
 				try {
-					// split each line along the commas
-					fileData = line.trim().split(",", -1);
+					// parse each CSV record without letting quoted commas shift columns
+					fileData = CsvReader.parseRecord(line.trim());
 					
 					// Validate data
 					if (fileData.length < 18) {
@@ -298,10 +298,10 @@ public class Blocks implements Comparable<Blocks> {
 
 					// fileData[0] corresponds to block number, fileData[9] to miner address
 					// fileData[16] corresponds to unix timestamp, fileData[17] corresponds to transaction count
-					int blockNumber = Integer.parseInt(fileData[0]);
-					String minerAddress = fileData[9];
-					long timestamp = Long.parseLong(fileData[16]);
-					int transactionCount = Integer.parseInt(fileData[17]);
+					int blockNumber = Integer.parseInt(fileData[0].trim());
+					String minerAddress = fileData[9].trim();
+					long timestamp = Long.parseLong(fileData[16].trim());
+					int transactionCount = Integer.parseInt(fileData[17].trim());
 					
 					// Validate parsed data
 					if (blockNumber < 0) {
@@ -600,23 +600,24 @@ public class Blocks implements Comparable<Blocks> {
 			String firstSkippedReason = null;
 			while ((line = reader.readLine()) != null) {
 				lineNumber++;
-				String[] fileData = line.trim().split(",", -1);
-				if (fileData.length < 10) {
-					skippedTransactionRows++;
-					if (firstSkippedLine < 0) {
-						firstSkippedLine = lineNumber;
-						firstSkippedReason = "Expected at least 10 columns";
-					}
-					continue;
-				}
 
 				try {
-					int tranNumber = Integer.parseInt(fileData[3]);
-					int tranIndex = Integer.parseInt(fileData[4]);
-					int tranGasLimit = Integer.parseInt(fileData[8]);
-					long tranGasPrice = (long) Double.parseDouble(fileData[9]);
-					String tranFromAdr = fileData[5];
-					String tranToAdr = fileData[6];
+					String[] fileData = CsvReader.parseRecord(line.trim());
+					if (fileData.length < 10) {
+						skippedTransactionRows++;
+						if (firstSkippedLine < 0) {
+							firstSkippedLine = lineNumber;
+							firstSkippedReason = "Expected at least 10 columns";
+						}
+						continue;
+					}
+
+					int tranNumber = Integer.parseInt(fileData[3].trim());
+					int tranIndex = Integer.parseInt(fileData[4].trim());
+					int tranGasLimit = Integer.parseInt(fileData[8].trim());
+					long tranGasPrice = (long) Double.parseDouble(fileData[9].trim());
+					String tranFromAdr = fileData[5].trim();
+					String tranToAdr = fileData[6].trim();
 
 					Transaction nT = new Transaction(tranNumber, tranIndex, tranGasLimit, tranGasPrice, tranFromAdr, tranToAdr);
 					indexedTransactionsByBlock

--- a/src/CsvReader.java
+++ b/src/CsvReader.java
@@ -1,0 +1,68 @@
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal RFC 4180-style CSV record parser used by the Java CLI.
+ *
+ * The Ethereum exports can contain long calldata and metadata fields. Those
+ * fields are data, not delimiters, so plain String.split(",") is not safe for
+ * production-grade ingestion. This parser handles quoted fields, escaped quotes,
+ * empty cells, and trailing empty cells without pulling in a runtime dependency.
+ */
+public final class CsvReader {
+    private CsvReader() {
+        // Utility class.
+    }
+
+    public static String[] parseRecord(String record) {
+        if (record == null) {
+            throw new IllegalArgumentException("CSV record cannot be null");
+        }
+
+        List<String> fields = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean inQuotes = false;
+        boolean quotedField = false;
+
+        for (int i = 0; i < record.length(); i++) {
+            char current = record.charAt(i);
+
+            if (current == '"') {
+                if (inQuotes && i + 1 < record.length() && record.charAt(i + 1) == '"') {
+                    field.append('"');
+                    i++;
+                    continue;
+                }
+
+                if (!inQuotes && field.length() == 0) {
+                    quotedField = true;
+                    inQuotes = true;
+                    continue;
+                }
+
+                if (inQuotes) {
+                    inQuotes = false;
+                    continue;
+                }
+            }
+
+            if (current == ',' && !inQuotes) {
+                fields.add(field.toString());
+                field.setLength(0);
+                quotedField = false;
+                continue;
+            }
+
+            if (quotedField || current != '\r') {
+                field.append(current);
+            }
+        }
+
+        if (inQuotes) {
+            throw new IllegalArgumentException("Unclosed quoted CSV field");
+        }
+
+        fields.add(field.toString());
+        return fields.toArray(new String[0]);
+    }
+}

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -544,6 +544,7 @@ public class EthereumBlockExplorer {
             "  - The vendored JUnit runner in tools/",
             "  - Dataset files in the repo root: ethereumP1data.csv and ethereumtransactions1.csv",
             "  - Node.js for 'make cli-smoke', 'make ui-smoke', and 'make verify'",
+            "  - Playwright browser binaries via 'npx playwright install chromium'",
             "  - Python 3 to serve the browser UI with 'make ui'",
             "");
     }

--- a/src/TestBlocks.java
+++ b/src/TestBlocks.java
@@ -160,6 +160,29 @@ class TestBlocks {
 	}
 
 	@Test
+	void testTransactionLoaderHandlesQuotedCommasBeforeIndexedColumns() throws IOException {
+		String validFrom = "0x89abcdef0123456789abcdef0123456789abcdef";
+		String validTo = "0x1234567890abcdef1234567890abcdef12345678";
+		Path tempFile = Files.createTempFile("ethereumtransactions-quoted", ".csv");
+		Files.write(tempFile, List.of(
+			"hash,195893,\"parent,hash\",15049308,7," + validFrom + "," + validTo + ",0,21000,1000000000,calldata"
+		));
+
+		try {
+			Blocks.loadTransactionCacheForFile(tempFile.toString());
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+
+		ArrayList<Transaction> loaded = Blocks.getCachedTransactionsForBlock(15049308);
+		assertEquals(1, loaded.size());
+		assertEquals(7, loaded.get(0).getIndex());
+		assertEquals(validFrom, loaded.get(0).getFromAddress());
+		assertEquals(validTo, loaded.get(0).getToAddress());
+		assertEquals(0, Blocks.getSkippedTransactionRowCount());
+	}
+
+	@Test
 	void testBlockLoadWarningsAreCapturedWithoutPrinting() throws IOException {
 		List<String> originalRows = Files.readAllLines(Path.of("ethereumP1data.csv"));
 		Path tempFile = Files.createTempFile("ethereum-blocks-warning", ".csv");
@@ -176,6 +199,27 @@ class TestBlocks {
 
 		assertTrue(Blocks.getLoadWarnings().stream().anyMatch((warning) -> warning.contains("insufficient data")));
 		assertEquals("", errorStreamCaptor.toString().trim());
+	}
+
+	@Test
+	void testReadFileHandlesQuotedCommasWithoutColumnDrift() throws IOException {
+		String validMiner = "0x1234567890abcdef1234567890abcdef12345678";
+		Path tempFile = Files.createTempFile("ethereum-blocks-quoted", ".csv");
+		Files.write(tempFile, List.of(
+			"15049308,parent,uncle,nonce,sha3,logs,txroot,state,receipts," + validMiner + ",difficulty,total,size,\"extra,data with comma\",gaslimit,gasused,1656575372,342,basefee"
+		));
+
+		try {
+			ArrayList<Blocks> loaded = Blocks.readFile(tempFile.toString());
+
+			assertEquals(1, loaded.size());
+			assertEquals(15049308, loaded.get(0).getNumber());
+			assertEquals(validMiner, loaded.get(0).getMiner());
+			assertEquals(1656575372L, loaded.get(0).getTimestamp());
+			assertEquals(342, loaded.get(0).getTransactionCount());
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
 	}
 
 	@Test

--- a/src/TestCsvReader.java
+++ b/src/TestCsvReader.java
@@ -1,0 +1,26 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TestCsvReader {
+
+    @Test
+    void testParsesQuotedCommasAndEscapedQuotes() {
+        String[] fields = CsvReader.parseRecord("alpha,\"bravo, charlie\",\"delta \"\"echo\"\"\",,");
+
+        assertArrayEquals(
+            new String[] {"alpha", "bravo, charlie", "delta \"echo\"", "", ""},
+            fields
+        );
+    }
+
+    @Test
+    void testRejectsUnclosedQuotedField() {
+        IllegalArgumentException error = assertThrows(
+            IllegalArgumentException.class,
+            () -> CsvReader.parseRecord("alpha,\"broken")
+        );
+
+        assertTrue(error.getMessage().contains("Unclosed quoted CSV field"));
+    }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -430,13 +430,14 @@
   }
 
   function parseBlocks(csvText) {
-    return csvText.split(/\r?\n/).filter(Boolean).map(function (line) {
-      const parts = line.split(",");
+    return parseCsvRecords(csvText).filter(function (parts) {
+      return parts.length >= 18;
+    }).map(function (parts) {
       return {
-        number: Number(parts[0]),
-        miner: parts[9].toLowerCase(),
-        timestamp: Number(parts[16]),
-        transactionCountMetadata: Number(parts[17])
+        number: Number(parts[0].trim()),
+        miner: parts[9].trim().toLowerCase(),
+        timestamp: Number(parts[16].trim()),
+        transactionCountMetadata: Number(parts[17].trim())
       };
     });
   }
@@ -444,23 +445,18 @@
   function parseTransactions(csvText) {
     const transactions = [];
 
-    csvText.split(/\r?\n/).forEach(function (line) {
-      if (!line) {
-        return;
-      }
-
-      const parts = line.split(",");
+    parseCsvRecords(csvText).forEach(function (parts) {
       if (parts.length < 10) {
         return;
       }
 
-      const from = (parts[5] || "").toLowerCase();
-      const rawTo = (parts[6] || "").toLowerCase();
+      const from = (parts[5] || "").trim().toLowerCase();
+      const rawTo = (parts[6] || "").trim().toLowerCase();
       const to = rawTo || "contract_creation";
-      const gasLimit = Number(parts[8]);
-      const gasPrice = Number(parts[9]);
-      const blockNumber = Number(parts[3]);
-      const index = Number(parts[4]);
+      const gasLimit = Number(parts[8].trim());
+      const gasPrice = Number(parts[9].trim());
+      const blockNumber = Number(parts[3].trim());
+      const index = Number(parts[4].trim());
 
       if (!looksLikeAddress(from)) {
         return;
@@ -482,6 +478,72 @@
     });
 
     return transactions;
+  }
+
+  function parseCsvRecords(csvText) {
+    const rows = [];
+    let row = [];
+    let field = "";
+    let inQuotes = false;
+    let quotedField = false;
+
+    for (let i = 0; i < csvText.length; i++) {
+      const current = csvText[i];
+
+      if (current === '"') {
+        if (inQuotes && csvText[i + 1] === '"') {
+          field += '"';
+          i += 1;
+          continue;
+        }
+
+        if (!inQuotes && field.length === 0) {
+          quotedField = true;
+          inQuotes = true;
+          continue;
+        }
+
+        if (inQuotes) {
+          inQuotes = false;
+          continue;
+        }
+      }
+
+      if (current === "," && !inQuotes) {
+        row.push(field);
+        field = "";
+        quotedField = false;
+        continue;
+      }
+
+      if ((current === "\n" || current === "\r") && !inQuotes) {
+        if (current === "\r" && csvText[i + 1] === "\n") {
+          i += 1;
+        }
+        row.push(field);
+        if (row.some(function (value) { return value.length > 0; })) {
+          rows.push(row);
+        }
+        row = [];
+        field = "";
+        quotedField = false;
+        continue;
+      }
+
+      if (quotedField || current !== "\r") {
+        field += current;
+      }
+    }
+
+    if (inQuotes) {
+      throw new Error("Unclosed quoted CSV field.");
+    }
+
+    row.push(field);
+    if (row.some(function (value) { return value.length > 0; })) {
+      rows.push(row);
+    }
+    return rows;
   }
 
   function buildDataset(blocks, transactions) {


### PR DESCRIPTION
### Motivation
- Prevent CSV column drift caused by quoted commas and escaped quotes so financial and address columns are parsed reliably across CLI and browser surfaces. 
- Keep browser and CLI ingestion aligned to avoid divergent analysis results that could produce incorrect intelligence. 
- Make local runtime behavior predictable with a small `.env` contract and clearer browser-smoke requirements. 
- Harden the UI smoke server to avoid trivial directory-traversal issues when serving static preview files.

### Description
- Add `src/CsvReader.java`, a minimal RFC-4180-style CSV record parser, and replace fragile `String.split(",")` calls in `src/Blocks.java` transaction and block loaders with `CsvReader.parseRecord(...)` plus trimmed numeric/address fields. 
- Mirror quote-aware parsing in the browser UI by adding `parseCsvRecords()` and replacing ad-hoc `split` logic in `web/app.js` so browser and CLI interpret CSV exports identically. 
- Add regression tests: `src/TestCsvReader.java` for CSV edge cases and new `TestBlocks` cases verifying quoted-field handling for both block rows and transaction rows. 
- Add runtime and developer hygiene: `.env.example`, include `.env` from `Makefile`, make `UI_PORT` configurable, and update `README.md` with Playwright/browser-install guidance. 
- Bump Playwright to `^1.59.1` and add `npm` script `ui:install-browsers` to align with current Playwright browser install flow. 
- Harden `scripts/ui_smoke.mjs` static server path validation using `path.relative` to prevent unsafe path prefix checks and make the UI smoke script more robust.

### Testing
- Ran the full JUnit suite with `make test` and all new and existing tests passed (58/58). 
- Verified CSV parser unit tests with the added `TestCsvReader` and new `TestBlocks` quoted-field regression tests; they passed under the JUnit run. 
- Ran `npm audit --audit-level=moderate` and `make cli-smoke`, both succeeded (CLI smoke and npm audit reported no issues). 
- Confirmed `npx playwright --version` reflects the upgraded dependency (`1.59.1`). 
- Attempted `npm run ui:install-browsers` and `make ui-smoke` but they are blocked in this environment because Playwright cannot download Chromium from the CDN (download failed with HTTP 403 `Domain forbidden`), so end-to-end browser smoke in CI-like mode could not complete here. 
- `make verify` ran JUnit and CLI smoke successfully then failed at browser smoke for the same CDN download restriction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0093da57d08330b2b518c08b8544e3)