### PR TITLE
Add one‑call agent snapshot, snapshot CLI, and modernize Playwright/CI verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,18 +10,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '25'
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install browser smoke dependencies

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ JUNIT_JAR = $(TOOLSDIR)/junit-platform-console-standalone-$(JUNIT_VERSION).jar
 REPORT_FILE = ethereum-report.md
 UI_PORT ?= 4173
 
-.PHONY: help build compile run run-json dashboard block address brief network anomalies miners report clean check-java check-junit test verify ui ui-build ui-serve ui-clean ui-smoke cli-smoke check-python check-ui-data check-node
+.PHONY: help build compile run run-json dashboard block address brief snapshot network anomalies miners report clean check-java check-junit test verify ui ui-build ui-serve ui-clean ui-smoke cli-smoke check-python check-ui-data check-node
 
 help:
 	@echo "Ethereum Block Explorer v5.0"
@@ -41,6 +41,7 @@ help:
 	@echo "  make report               Write ethereum-report.md"
 	@echo "  make run                  Open the small interactive menu"
 	@echo "  make brief                Print the action brief"
+	@echo "  make snapshot             Print the one-call agent snapshot in JSON"
 	@echo "  make anomalies THRESHOLD=1.5  Print anomaly analysis in JSON"
 	@echo "  make miners               Print the unique miner breakdown in JSON"
 	@echo "  make run-json             Print the JSON overview"
@@ -59,7 +60,7 @@ help:
 	@echo "  - The vendored JUnit runner in $(TOOLSDIR)/"
 	@echo "  - Dataset files in the repo root: ethereumP1data.csv and ethereumtransactions1.csv"
 	@echo "  - Node.js for 'make cli-smoke', 'make ui-smoke', and 'make verify'"
-	@echo "  - Playwright browser binaries via 'npx playwright install chromium'"
+	@echo "  - Playwright browser binaries via 'npx playwright install --with-deps chromium'"
 	@echo "  - Python 3 to serve the browser UI with 'make ui'"
 
 build: compile
@@ -127,7 +128,7 @@ ui-clean:
 
 ui-smoke: ui-build check-node
 	@if [ ! -d node_modules/playwright ]; then \
-		echo "Browser smoke dependencies missing. Run 'npm ci' and 'npx playwright install chromium', then rerun 'make ui-smoke'."; \
+		echo "Browser smoke dependencies missing. Run 'npm ci' and 'npm run ui:install-browsers', then rerun 'make ui-smoke'."; \
 		exit 1; \
 	fi
 	@node scripts/ui_smoke.mjs
@@ -154,6 +155,9 @@ address: compile
 
 brief: compile
 	@$(JAVA) $(MAIN) brief
+
+snapshot: compile
+	@$(JAVA) $(MAIN) --json snapshot
 
 network: compile
 	@$(JAVA) $(MAIN) --json network

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Write a shareable markdown report:
 make report
 ```
 
+Give an agent one compact context packet:
+
+```bash
+make snapshot
+```
+
 ## Supported Commands
 
 | Command | What it does |
@@ -61,6 +67,7 @@ make report
 | `make report` | Write `ethereum-report.md` |
 | `make run` | Open the small interactive menu |
 | `make brief` | Print the action brief |
+| `make snapshot` | Return the one-call agent snapshot in JSON |
 | `make anomalies THRESHOLD=1.5` | Return anomaly analysis in JSON |
 | `make miners` | Return the unique miner breakdown in JSON |
 | `make run-json` | Print the JSON overview |
@@ -74,7 +81,7 @@ make report
 | `make ui-clean` | Remove generated browser preview files |
 
 `make test` uses the vendored JUnit console runner in the repo, so it does not need to fetch test tooling before it runs.
-`make cli-smoke` uses Node.js plus the normal CLI prerequisites: the CSV dataset files and a working Java runtime and JDK. `make ui-smoke` uses Node.js plus Playwright after `npm ci` and a Chromium browser install with `npx playwright install chromium`.
+`make cli-smoke` uses Node.js plus the normal CLI prerequisites: the CSV dataset files and a working Java runtime and JDK. `make ui-smoke` uses Node.js plus Playwright after `npm ci` and a Chromium browser install with `npx playwright install --with-deps chromium`.
 `make verify` runs the same local contract as CI: the JUnit suite, the CLI smoke checks, and the browser build plus smoke path.
 
 ## Browser UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "ethereum-block-explorer",
       "devDependencies": {
-        "playwright": "^1.59.1"
+        "playwright": "^1.60.0"
       }
     },
     "node_modules/fsevents": {
@@ -25,13 +25,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "scripts": {
     "ui:smoke": "node scripts/ui_smoke.mjs",
-    "ui:install-browsers": "playwright install chromium"
+    "ui:install-browsers": "playwright install --with-deps chromium"
   },
   "devDependencies": {
-    "playwright": "^1.59.1"
+    "playwright": "^1.60.0"
   }
 }

--- a/scripts/cli_smoke.mjs
+++ b/scripts/cli_smoke.mjs
@@ -79,6 +79,12 @@ try {
   assertCondition(brief.includes("ETHEREUM ACTION BRIEF"), "Brief output did not render.");
   assertCondition(brief.includes("Strategic signals:"), "Brief output is missing strategic signals.");
 
+  const snapshot = parseJsonOutput(["snapshot"]);
+  assertCondition(snapshot.schema === "ethereum-block-explorer.agent-snapshot.v1", "Snapshot schema mismatch.");
+  assertCondition(snapshot.status === "ready", "Snapshot is not ready.");
+  assertCondition(snapshot.data_contract.blocks_file === "ethereumP1data.csv", "Snapshot data contract missing blocks file.");
+  assertCondition(Array.isArray(snapshot.recommended_next_actions), "Snapshot is missing recommended next actions.");
+
   const overview = parseJsonOutput(["run-json"]);
   assertCondition(overview.blocks_loaded === 100, "Overview blocks_loaded mismatch.");
   assertCondition(Array.isArray(overview.top_miners), "Overview is missing top_miners.");

--- a/scripts/ui_smoke.mjs
+++ b/scripts/ui_smoke.mjs
@@ -67,10 +67,11 @@ function assertCondition(condition, message) {
 const server = await startStaticServer(root);
 const addressInfo = server.address();
 const baseUrl = `http://127.0.0.1:${addressInfo.port}`;
-const browser = await chromium.launch({ headless: true });
 const invalidAddress = `0x${"z".repeat(40)}`;
+let browser;
 
 try {
+  browser = await launchBrowser();
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   await page.goto(baseUrl, { waitUntil: "networkidle" });
 
@@ -120,8 +121,24 @@ try {
 
   console.log("UI smoke passed.");
 } finally {
-  await browser.close();
+  if (browser) {
+    await browser.close();
+  }
   await new Promise((resolveClose, rejectClose) => {
     server.close((error) => (error ? rejectClose(error) : resolveClose()));
   });
+}
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch({ headless: true });
+  } catch (error) {
+    if (error && String(error.message || "").includes("Executable doesn't exist")) {
+      throw new Error(
+        "Playwright Chromium is not installed for the current Playwright version. Run `npm run ui:install-browsers`, then rerun `make ui-smoke`.",
+        { cause: error }
+      );
+    }
+    throw error;
+  }
 }

--- a/src/AgentAPI.java
+++ b/src/AgentAPI.java
@@ -205,6 +205,34 @@ public final class AgentAPI {
     }
 
     /**
+     * One-call agent snapshot — compact enough for LLM context, complete enough to route work.
+     */
+    public static Map<String, Object> agentSnapshot(ArrayList<Blocks> blocks) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("schema", "ethereum-block-explorer.agent-snapshot.v1");
+        result.put("purpose", "one-call context packet for agents, dashboards, and health checks");
+
+        Map<String, Object> overview = overview(blocks, 5);
+        result.put("overview", overview);
+
+        if (overview.containsKey("error")) {
+            result.put("status", "unavailable");
+            return result;
+        }
+
+        Map<String, Object> network = NetworkAnalyzer.analyzeNetwork(blocks, 5);
+        Map<String, Object> anomalies = detectAnomalies(blocks, 1.5);
+
+        result.put("network", network);
+        result.put("anomalies", anomalies);
+        result.put("data_contract", buildDataContract(overview));
+        result.put("recommended_next_actions", recommendedNextActions(overview, network, anomalies));
+        result.put("status", "ready");
+
+        return result;
+    }
+
+    /**
      * Compare two blocks — structured diff for agent reasoning.
      */
     public static Map<String, Object> compareBlocks(ArrayList<Blocks> blocks, int blockA, int blockB) {
@@ -404,6 +432,52 @@ public final class AgentAPI {
             if (b.getNumber() == number) return b;
         }
         return null;
+    }
+
+    private static Map<String, Object> buildDataContract(Map<String, Object> overview) {
+        Map<String, Object> contract = new LinkedHashMap<>();
+        contract.put("blocks_file", Blocks.DEFAULT_BLOCKS_FILE);
+        contract.put("transactions_file", Blocks.DEFAULT_TRANSACTIONS_FILE);
+        contract.put("block_range_start", overview.get("block_range_start"));
+        contract.put("block_range_end", overview.get("block_range_end"));
+        contract.put("blocks_loaded", overview.get("blocks_loaded"));
+        contract.put("parsed_transactions", overview.get("parsed_transactions"));
+        contract.put("address_format", "0x followed by 40 hexadecimal characters");
+        return contract;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> recommendedNextActions(
+        Map<String, Object> overview,
+        Map<String, Object> network,
+        Map<String, Object> anomalies
+    ) {
+        List<String> actions = new ArrayList<>();
+
+        Map<String, Object> concentration = (Map<String, Object>) overview.get("concentration_risk");
+        if (concentration != null) {
+            Object level = concentration.get("level");
+            if ("critical".equals(level) || "high".equals(level)) {
+                actions.add("Investigate miner concentration before using the sample for decentralization claims.");
+            }
+        }
+
+        List<Map<String, Object>> costAnomalies = (List<Map<String, Object>>) anomalies.get("cost_anomalies");
+        if (costAnomalies != null && !costAnomalies.isEmpty()) {
+            actions.add("Review cost_anomalies first; high z-score blocks are the fastest path to unusual-flow explanations.");
+        }
+
+        List<Map<String, Object>> whales = (List<Map<String, Object>>) network.get("whales");
+        if (whales != null && !whales.isEmpty()) {
+            Object address = whales.get(0).get("address");
+            actions.add("Profile the top whale address with make address ADDR=" + address + ".");
+        }
+
+        if (actions.isEmpty()) {
+            actions.add("Start with make dashboard, then inspect the highest-volume block from hot blocks.");
+        }
+
+        return actions;
     }
 
     private static Map<String, Object> concentrationRisk(Map<String, Integer> freq, int totalBlocks) {

--- a/src/EthereumBlockExplorer.java
+++ b/src/EthereumBlockExplorer.java
@@ -78,6 +78,9 @@ public class EthereumBlockExplorer {
                         Insights.printActionBrief(blocks, 5);
                     }
                     break;
+                case "snapshot":
+                    outputResult(AgentAPI.agentSnapshot(blocks));
+                    break;
                 case "report":
                     writeReport(args.length >= 2 ? args[1] : "ethereum-report.md");
                     break;
@@ -526,6 +529,7 @@ public class EthereumBlockExplorer {
             "  make report               Write ethereum-report.md",
             "  make run                  Open the small interactive menu",
             "  make brief                Print the action brief",
+            "  make snapshot             Print the one-call agent snapshot in JSON",
             "  make anomalies THRESHOLD=1.5  Print anomaly analysis in JSON",
             "  make miners               Print the unique miner breakdown in JSON",
             "  make run-json             Print the JSON overview",
@@ -544,7 +548,7 @@ public class EthereumBlockExplorer {
             "  - The vendored JUnit runner in tools/",
             "  - Dataset files in the repo root: ethereumP1data.csv and ethereumtransactions1.csv",
             "  - Node.js for 'make cli-smoke', 'make ui-smoke', and 'make verify'",
-            "  - Playwright browser binaries via 'npx playwright install chromium'",
+            "  - Playwright browser binaries via 'npx playwright install --with-deps chromium'",
             "  - Python 3 to serve the browser UI with 'make ui'",
             "");
     }

--- a/src/TestAgentAPI.java
+++ b/src/TestAgentAPI.java
@@ -141,4 +141,23 @@ class TestAgentAPI {
         assertNotNull(contractCreationTx);
         assertEquals(Transaction.CONTRACT_CREATION_RECIPIENT, contractCreationTx.get("to"));
     }
+
+    @Test
+    void testAgentSnapshotReturnsOneCallContext() {
+        Map<String, Object> snapshot = AgentAPI.agentSnapshot(blocks);
+        assertEquals("ethereum-block-explorer.agent-snapshot.v1", snapshot.get("schema"));
+        assertEquals("ready", snapshot.get("status"));
+        assertTrue(snapshot.containsKey("overview"));
+        assertTrue(snapshot.containsKey("network"));
+        assertTrue(snapshot.containsKey("anomalies"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dataContract = (Map<String, Object>) snapshot.get("data_contract");
+        assertEquals(Blocks.DEFAULT_BLOCKS_FILE, dataContract.get("blocks_file"));
+        assertEquals(Blocks.DEFAULT_TRANSACTIONS_FILE, dataContract.get("transactions_file"));
+
+        @SuppressWarnings("unchecked")
+        List<String> nextActions = (List<String>) snapshot.get("recommended_next_actions");
+        assertFalse(nextActions.isEmpty());
+    }
 }

--- a/src/TestEthereumBlockExplorer.java
+++ b/src/TestEthereumBlockExplorer.java
@@ -24,6 +24,7 @@ class TestEthereumBlockExplorer {
         assertTrue(help.contains("make test"));
         assertTrue(help.contains("make cli-smoke"));
         assertTrue(help.contains("make ui-smoke"));
+        assertTrue(help.contains("make snapshot"));
         assertTrue(help.contains("vendored JUnit runner"));
         assertFalse(help.contains("Open the visual explorer"));
         assertFalse(help.contains("java -cp"));


### PR DESCRIPTION
### Motivation
- Provide a single compact, machine-friendly context packet for agents/LLMs to bootstrap analysis and reduce friction for agentic workflows.
- Surface the snapshot through the existing make-first CLI and tests so automation and CI can rely on a stable contract.
- Modernize smoke/CI tooling and browser install guidance to a recent Playwright version and clearer recovery steps.

### Description
- Added `AgentAPI.agentSnapshot(ArrayList<Blocks>)` which returns an agent-friendly JSON packet containing `overview`, `network`, `anomalies`, `data_contract`, `recommended_next_actions`, `schema`, and `status`. (`src/AgentAPI.java`)
- Implemented helpers `buildDataContract(...)` and `recommendedNextActions(...)` to include a reproducible data contract and concise next-step recommendations for agents. (`src/AgentAPI.java`)
- Wired the snapshot into the CLI as `--json snapshot` and added `make snapshot` to the Makefile and CLI help text. (`src/EthereumBlockExplorer.java`, `Makefile`, `README.md`)
- Added smoke/unit coverage for the snapshot contract and help text updates; new unit test `testAgentSnapshotReturnsOneCallContext`. (`src/TestAgentAPI.java`, `scripts/cli_smoke.mjs`)
- Upgraded Playwright to `^1.60.0` and changed `ui:install-browsers` to `playwright install --with-deps chromium`; improved `ui_smoke` to surface a clear recovery message when the matching Playwright browser binary is missing. (`package.json`, `package-lock.json`, `scripts/ui_smoke.mjs`)
- Bumped CI workflow to newer action majors and updated tool versions for reproducible verification (`.github/workflows/verify.yml`).

### Testing
- Ran `make test` (JUnit suite) — all tests passed (59 tests successful).
- Ran `make cli-smoke` — completed and validated the snapshot assertions (passed).
- Ran `make ui-build` — succeeded (static UI files produced).
- Ran `make snapshot` — produced the new snapshot JSON with the expected `schema` and `status: ready` (sample printed during the run).
- Ran `npm run ui:install-browsers` — system dependencies installed, but browser download failed due to an external network policy (CDN returned `Domain forbidden`); this prevented `make ui-smoke` from running in this environment and is surfaced by the improved diagnostic message that instructs `npm run ui:install-browsers` as the recovery step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055784d0d08330bf24c9d1d311b2c6)