### PR TITLE
Tighten summary card pattern and result-meta separator

### DIFF
--- a/scripts/ui_smoke.mjs
+++ b/scripts/ui_smoke.mjs
@@ -78,7 +78,7 @@ try {
   assertCondition(await page.title() === "Ethereum Block Explorer", "Unexpected browser title.");
   await page.getByRole("heading", { name: "Block 15049311" }).waitFor();
   assertCondition(
-    await page.getByText("100 loaded blocks").isVisible(),
+    await page.getByText("100 blocks", { exact: true }).first().isVisible(),
     "Overview summary did not render."
   );
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -41,9 +41,9 @@ export function renderSummary(state, elements) {
   const overview = state.data.overview;
   elements.summaryStrip.innerHTML = [
     renderSummaryItem(
-      "Sample",
-      formatRange(overview.blockRangeStart, overview.blockRangeEnd),
-      overview.blocksLoaded + " loaded blocks"
+      "Loaded",
+      formatInteger(overview.blocksLoaded) + " blocks",
+      formatRange(overview.blockRangeStart, overview.blockRangeEnd)
     ),
     renderSummaryItem(
       "Miners",
@@ -128,7 +128,7 @@ export function renderBlock(rawBlock, state, elements) {
   swapResult(function () {
     elements.resultKicker.textContent = "Block";
     elements.resultTitle.textContent = "Block " + block.number;
-    elements.resultMeta.textContent = block.displayTimestamp + "  |  Miner " + shorten(block.miner);
+    elements.resultMeta.textContent = block.displayTimestamp + "  ·  Miner " + shorten(block.miner);
 
     const statGrid = [
       renderStat(
@@ -197,7 +197,7 @@ export function renderAddress(rawAddress, state, elements) {
     elements.resultKicker.textContent = "Address";
     elements.resultTitle.textContent = shorten(profile.address);
     elements.resultMeta.textContent =
-      "Active from block " + profile.firstBlock + " to " + profile.lastBlock + "  |  " + profile.behaviorClass.replace("_", " ");
+      "Active from block " + profile.firstBlock + " to " + profile.lastBlock + "  ·  " + profile.behaviorClass.replace("_", " ");
 
     const statGrid = [
       renderStat("Touches", formatInteger(profile.totalInteractions)),


### PR DESCRIPTION
## Summary

- The summary strip's `Sample` card displayed a hyphenated block range as its serif value, which soft-wrapped to two stacked numbers on the main breakpoint and broke the single-value-with-note pattern shared by the other three cards. Rename to `Loaded`, use the block count as the value, and move the range to the supporting note so all four cards share the same shape.
- Replace the `|` separator in block and address `result-meta` with `·` so the editorial typography reads cleanly.
- Update the overview smoke assertion to match the new copy.

## Test plan

- [x] `make ui-build`
- [x] `make ui-smoke`
- [x] Visual check at `/`, `/#block/15049311`, and `/#address/0x58a5b1a1c67e984247a0c78f2875b0f9c781b64f`