### PR TITLE
Production polish: OG, security headers, analytics, cleaner copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ui: ui-serve
 ui-build: check-ui-data
 	@rm -rf web/dist
 	@mkdir -p web/dist
-	@cp web/*.html web/*.css web/*.js web/*.svg ethereumP1data.csv ethereumtransactions1.csv web/dist/
+	@cp web/*.html web/*.css web/*.js web/*.svg web/robots.txt web/sitemap.xml ethereumP1data.csv ethereumtransactions1.csv web/dist/
 
 ui-serve: check-python ui-build
 	@echo "Serving visual explorer at http://localhost:$(UI_PORT)"

--- a/scripts/ui_smoke.mjs
+++ b/scripts/ui_smoke.mjs
@@ -75,7 +75,7 @@ try {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   await page.goto(baseUrl, { waitUntil: "networkidle" });
 
-  assertCondition(await page.title() === "Ethereum Block Explorer", "Unexpected browser title.");
+  assertCondition((await page.title()).startsWith("Ethereum Block Explorer"), "Unexpected browser title.");
   await page.getByRole("heading", { name: "Block 15049311" }).waitFor();
   assertCondition(
     await page.getByText("100 blocks", { exact: true }).first().isVisible(),

--- a/vercel.json
+++ b/vercel.json
@@ -2,23 +2,30 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "make ui-build",
   "outputDirectory": "web/dist",
+  "cleanUrls": true,
   "headers": [
     {
-      "source": "/(.*)\\.(css|js)",
+      "source": "/(.*)",
       "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31556952, immutable"
-        }
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "geolocation=(), camera=(), microphone=(), payment=(), interest-cohort=()" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(css|js|svg)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31556952, immutable" }
       ]
     },
     {
       "source": "/(.*)\\.csv",
       "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=3600"
-        }
+        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800" }
       ]
     }
   ]

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,25 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ethereum Block Explorer</title>
+  <title>Ethereum Block Explorer — a focused chain reader</title>
   <meta
     name="description"
-    content="Search a 100-block Ethereum sample in a lean browser UI. Inspect one block, trace one address, and jump between both in seconds."
+    content="Inspect one Ethereum block or trace one address across a curated 100-block slice. Numbers exact, hex monospace, nothing the dataset cannot back."
   >
   <meta name="theme-color" content="#07080a">
+  <meta name="color-scheme" content="dark">
+  <link rel="canonical" href="https://blockchain-network-ui.vercel.app/">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Ethereum Block Explorer">
+  <meta property="og:url" content="https://blockchain-network-ui.vercel.app/">
+  <meta property="og:title" content="Ethereum Block Explorer — a focused chain reader">
+  <meta property="og:description" content="Inspect one block or trace one address. Numbers exact, hex monospace, nothing the dataset cannot back.">
+  <meta property="og:image" content="https://blockchain-network-ui.vercel.app/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Ethereum Block Explorer">
+  <meta name="twitter:description" content="Inspect one block or trace one address. Numbers exact, hex monospace.">
+  <meta name="twitter:image" content="https://blockchain-network-ui.vercel.app/og.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
@@ -18,15 +30,18 @@
   >
   <link rel="stylesheet" href="./app.css">
   <script type="module" src="./app.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="/_vercel/speed-insights/script.js"></script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Ethereum Block Explorer","url":"https://blockchain-network-ui.vercel.app/","description":"Inspect one Ethereum block or trace one address across a curated 100-block slice."}</script>
 </head>
 <body>
   <div class="page-shell">
     <header class="hero">
       <div class="hero-inner">
-        <p class="eyebrow">Ethereum block explorer — live sample</p>
+        <p class="eyebrow">Ethereum block explorer</p>
         <h1>One hundred blocks. <em>Read the chain</em> one row at a time.</h1>
         <p class="hero-copy">
-          Search one block or one address across the loaded sample. Numbers stay exact. Hex stays monospace. Nothing renders that the dataset cannot back.
+          Search one block or one address. Numbers stay exact. Hex stays monospace. Nothing renders that the dataset cannot back.
         </p>
 
         <form id="query-form" class="query-bar" novalidate>
@@ -76,7 +91,7 @@
         <section class="result-panel" aria-live="polite">
           <div class="panel-header">
             <div>
-              <p id="result-kicker" class="panel-kicker">Loading the sample...</p>
+              <p id="result-kicker" class="panel-kicker">Loading</p>
               <h2 id="result-title">Preparing the explorer</h2>
             </div>
             <p id="result-meta" class="panel-meta"></p>
@@ -114,7 +129,7 @@
     </main>
 
     <footer class="footer">
-      <p>Sample dataset · 100 blocks · static browser explorer</p>
+      <p>100 blocks · static browser explorer · no backend</p>
       <p><a href="https://github.com/pdj555/ethereum-blocks">github.com/pdj555/ethereum-blocks</a></p>
     </footer>
   </div>

--- a/web/og.svg
+++ b/web/og.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Ethereum Block Explorer">
+  <defs>
+    <radialGradient id="glow" cx="20%" cy="0%" r="80%">
+      <stop offset="0%" stop-color="#8eff6a" stop-opacity="0.18"/>
+      <stop offset="60%" stop-color="#07080a" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="warm" cx="100%" cy="10%" r="60%">
+      <stop offset="0%" stop-color="#ffad52" stop-opacity="0.10"/>
+      <stop offset="70%" stop-color="#07080a" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="64" height="64" patternUnits="userSpaceOnUse">
+      <path d="M 64 0 L 0 0 0 64" fill="none" stroke="#ece6d6" stroke-opacity="0.05" stroke-width="1"/>
+    </pattern>
+    <linearGradient id="ink" x1="0" x2="1">
+      <stop offset="0%" stop-color="#ece6d6"/>
+      <stop offset="100%" stop-color="#b9b4a8"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="#07080a"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  <rect width="1200" height="630" fill="url(#glow)"/>
+  <rect width="1200" height="630" fill="url(#warm)"/>
+  <g font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" fill="#6f6c63" letter-spacing="2">
+    <text x="80" y="100">ETHEREUM · BLOCK EXPLORER</text>
+  </g>
+  <g font-family="Fraunces, 'Iowan Old Style', Georgia, serif" fill="url(#ink)">
+    <text x="80" y="270" font-size="92" font-weight="600" letter-spacing="-2">One hundred blocks.</text>
+    <text x="80" y="370" font-size="92" font-weight="400" font-style="italic" fill="#8eff6a" letter-spacing="-2">Read the chain</text>
+    <text x="80" y="470" font-size="92" font-weight="600" letter-spacing="-2">one row at a time.</text>
+  </g>
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="22" fill="#b9b4a8">
+    <text x="80" y="555">Search a block · trace an address · numbers exact, hex monospace</text>
+  </g>
+  <g transform="translate(1040, 80)">
+    <rect width="80" height="80" rx="8" fill="#10131a" stroke="#ece6d6" stroke-opacity="0.18"/>
+    <path d="M40 18 26 40l14 8 14-8Z" fill="#ece6d6"/>
+    <path d="M40 52 26 43l14 20 14-20Z" fill="#8eff6a"/>
+  </g>
+</svg>

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -13,7 +13,7 @@ import {
 
 export function renderLoading(elements) {
   elements.summaryStrip.innerHTML = [
-    renderSummaryItem("Sample", "Loading", "Reading CSV data"),
+    renderSummaryItem("Blocks", "Loading", "Reading CSV data"),
     renderSummaryItem("Miners", "-", "Preparing counts"),
     renderSummaryItem("Transactions", "-", "Preparing activity"),
     renderSummaryItem("Addresses", "-", "Preparing search")
@@ -23,7 +23,7 @@ export function renderLoading(elements) {
   elements.hotBlocks.innerHTML = "";
   elements.activeAddresses.innerHTML = "";
   elements.networkGlance.innerHTML = "";
-  elements.resultKicker.textContent = "Loading the sample...";
+  elements.resultKicker.textContent = "Loading";
   elements.resultTitle.textContent = "Preparing the explorer";
   elements.resultMeta.textContent = "Reading block and transaction CSV data.";
   elements.resultBody.innerHTML =
@@ -118,7 +118,7 @@ export function renderBlock(rawBlock, state, elements) {
   if (!block) {
     renderMessage(
       "Block lookup",
-      "Block " + escapeHtml(rawBlock) + " is outside the loaded sample.",
+      "Block " + escapeHtml(rawBlock) + " is not in the loaded dataset.",
       "Choose a block between " + state.data.overview.blockRangeStart + " and " + state.data.overview.blockRangeEnd + ".",
       elements
     );
@@ -154,7 +154,7 @@ export function renderBlock(rawBlock, state, elements) {
           renderJump("address", item.address, shorten(item.address)),
           formatInteger(item.count) + " tx"
         );
-      }).join("") : "<div class='empty-state'><p>No parsed senders for this block in the loaded sample.</p></div>")
+      }).join("") : "<div class='empty-state'><p>No parsed senders for this block.</p></div>")
     ].join("");
 
     const transactions = block.transactions.length

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://blockchain-network-ui.vercel.app/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://blockchain-network-ui.vercel.app/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Open Graph + Twitter card meta, canonical URL, JSON-LD; new `web/og.svg`, `robots.txt`, `sitemap.xml`
- Vercel Analytics + Speed Insights scripts wired in `index.html` (project IDs already enabled)
- Security headers in `vercel.json`: HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, COOP, CORP; tighter CSV cache
- Removed apologetic "sample" framing from UI copy (eyebrow, footer, loading states, renderer messages)

## Test plan
- [x] `make ui-build` succeeds; new assets land in `web/dist/`
- [x] `make ui-smoke` passes (title assertion loosened to `startsWith` for the longer SEO title)
- [ ] Preview deploy renders correctly; OG image previews in social scrapers