### PR TITLE
Point canonical and OG URLs to ethereum-blocks.vercel.app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,18 +10,18 @@
   >
   <meta name="theme-color" content="#07080a">
   <meta name="color-scheme" content="dark">
-  <link rel="canonical" href="https://blockchain-network-ui.vercel.app/">
+  <link rel="canonical" href="https://ethereum-blocks.vercel.app/">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Ethereum Block Explorer">
-  <meta property="og:url" content="https://blockchain-network-ui.vercel.app/">
+  <meta property="og:url" content="https://ethereum-blocks.vercel.app/">
   <meta property="og:title" content="Ethereum Block Explorer — a focused chain reader">
   <meta property="og:description" content="Inspect one block or trace one address. Numbers exact, hex monospace, nothing the dataset cannot back.">
-  <meta property="og:image" content="https://blockchain-network-ui.vercel.app/og.svg">
+  <meta property="og:image" content="https://ethereum-blocks.vercel.app/og.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Ethereum Block Explorer">
   <meta name="twitter:description" content="Inspect one block or trace one address. Numbers exact, hex monospace.">
-  <meta name="twitter:image" content="https://blockchain-network-ui.vercel.app/og.svg">
+  <meta name="twitter:image" content="https://ethereum-blocks.vercel.app/og.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
@@ -32,7 +32,7 @@
   <script type="module" src="./app.js"></script>
   <script defer src="/_vercel/insights/script.js"></script>
   <script defer src="/_vercel/speed-insights/script.js"></script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Ethereum Block Explorer","url":"https://blockchain-network-ui.vercel.app/","description":"Inspect one Ethereum block or trace one address across a curated 100-block slice."}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Ethereum Block Explorer","url":"https://ethereum-blocks.vercel.app/","description":"Inspect one Ethereum block or trace one address across a curated 100-block slice."}</script>
 </head>
 <body>
   <div class="page-shell">

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://blockchain-network-ui.vercel.app/sitemap.xml
+Sitemap: https://ethereum-blocks.vercel.app/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://blockchain-network-ui.vercel.app/</loc>
+    <loc>https://ethereum-blocks.vercel.app/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
Follow-up to project rename (`blockchain-network-ui` → `ethereum-blocks`). Updates the 7 hardcoded URL strings so canonical, Open Graph, Twitter card, JSON-LD, sitemap, and robots all point at the new primary alias.

## Test plan
- [x] No remaining `blockchain-network-ui` references in `web/` source
- [ ] Preview deploy renders correctly with new URLs in head